### PR TITLE
Restructure to Vite+Phaser app; add GameState, CatRenderer, scenes, and Korean README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,121 @@
-# churu-city-game
-Churu &amp; The City – A casual cat labor game where you earn coins to unlock breeds, outfits, and build your royal cat kingdom.
+# 🐱 츄르앤더시티 (Churu & The City)
+
+> K-직장인 고양이 집사 라이프 게임  
+> Phaser 3 + Vite · Mobile Portrait (390×844)
+
+---
+
+## 🚀 빠른 시작
+
+```bash
+npm install
+npm run dev
+```
+
+브라우저에서 `http://localhost:3000` 접속 후, **모바일 세로 화면(390×844)** 으로 시뮬레이션하세요.  
+(Chrome DevTools → 모바일 에뮬레이터 권장)
+
+---
+
+## 📁 파일 구조
+
+```
+churu-and-the-city/
+├── index.html
+├── vite.config.js
+├── package.json
+├── src/
+│   ├── main.js                  # Phaser 게임 설정 & 씬 등록
+│   ├── utils/
+│   │   ├── GameState.js         # 전역 상태 관리 (코인, 체력, 기분)
+│   │   └── CatRenderer.js       # 고양이 레이어 조합 렌더링
+│   └── scenes/
+│       ├── PreloadScene.js      # 에셋 로딩
+│       ├── HomeScene.js         # 메인 홈 화면
+│       ├── GameSelectScene.js   # 미니게임 선택
+│       ├── FishGameScene.js     # 🐟 생선 세금 징수 (메인 미니게임)
+│       ├── SlotGameScene.js     # 🎰 츄르 복권
+│       ├── RatGameScene.js      # 🐀 쥐 단속
+│       └── DressRoomScene.js    # 👗 드레스룸
+└── public/
+    └── assets/                  # PNG 에셋 폴더 (아래 참조)
+```
+
+---
+
+## 🎮 게임 시스템
+
+### 전역 상태 (`GameState`)
+| 자원 | 설명 | 초기값 |
+|------|------|--------|
+| `coins` | 츄르값 (기본 재화) | 0 |
+| `stamina` | 집사 체력 (5분마다 1 회복) | 10 |
+| `catMood` | 고양이 기분 (2분마다 1 감소) | 80 |
+
+- 기분이 0이 되면 **스트레스성 병동 입원** → 코인 100 차감
+- 간식(30코인)으로 기분 +20 회복
+
+### 미니게임
+| 게임 | 소비 | 보상 |
+|------|------|------|
+| 🐟 생선 세금 징수 | 체력 1 | 생선 1마리당 코인 +2 |
+| 🎰 츄르 복권 | 코인 10 | 배율에 따라 코인 획득 |
+| 🐀 쥐 단속 | 체력 1 | 쥐 1마리당 코인 +3 |
+
+---
+
+## 🐾 고양이 레이어 렌더링
+
+`CatRenderer.js`의 `createCatContainer(scene, x, y, equipped, scale)` 함수가  
+아래 순서로 Phaser `Container` 내에 레이어를 적층합니다:
+
+```
+1. background  (배경)
+2. tail        (꼬리)
+3. body        (품종별 기본 바디)
+4. coat        (무늬/색상)
+5. clothes     (의상)
+6. accessories (악세사리)
+7. expression  (표정)
+```
+
+실제 PNG 에셋 없이도 **벡터 플레이스홀더**로 동작합니다.  
+에셋 추가 시 `PreloadScene.js`에서 `this.load.image(key, path)` 등록 후 자동 적용됩니다.
+
+---
+
+## 🖼️ 에셋 추가 방법
+
+`public/assets/` 폴더에 투명 PNG 파일을 배치하고,  
+`PreloadScene.js`의 `preload()` 메서드에 아래처럼 추가합니다:
+
+```js
+// 예시
+this.load.image('body_tuxedo',   'assets/cat/body_tuxedo.png');
+this.load.image('coat_black',    'assets/cat/coat_black.png');
+this.load.image('hat_crown',     'assets/items/hat_crown.png');
+this.load.image('bg_office',     'assets/backgrounds/bg_office.png');
+```
+
+이미지 키가 `GameState.equipped` 또는 드레스룸 아이템 `key`와 일치하면  
+자동으로 플레이스홀더 대신 실제 이미지가 렌더링됩니다.
+
+---
+
+## 🔧 확장 포인트
+
+- **새 미니게임 추가**: `GameSelectScene.js`의 `GAMES` 배열에 항목 추가
+- **새 아이템 추가**: `DressRoomScene.js`의 `ITEMS` 객체에 카테고리별 항목 추가
+- **스태미나/기분 밸런싱**: `GameState.js`의 상수값 조정
+- **세이브 기능**: `GameState._save()` / `_loadFromStorage()`가 `localStorage` 기반 퍼시스턴스 처리
+
+---
+
+## 📱 빌드 & 배포
+
+```bash
+npm run build    # dist/ 폴더 생성
+npm run preview  # 빌드 결과 미리보기
+```
+
+`dist/` 폴더를 Vercel, Netlify, GitHub Pages 등에 정적 배포하면 됩니다.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,33 @@
+<!doctype html>
+<html lang="ko">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, viewport-fit=cover" />
+    <title>츄르앤더시티</title>
+    <style>
+      html,
+      body {
+        margin: 0;
+        padding: 0;
+        background: #111;
+        height: 100%;
+        display: grid;
+        place-items: center;
+        font-family: 'Pretendard', 'Apple SD Gothic Neo', sans-serif;
+      }
+
+      #app {
+        width: 390px;
+        height: 844px;
+      }
+
+      canvas {
+        display: block;
+      }
+    </style>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module" src="/src/main.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "churu-and-the-city",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite --host 0.0.0.0 --port 3000",
+    "build": "vite build",
+    "preview": "vite preview --host 0.0.0.0 --port 4173"
+  },
+  "dependencies": {
+    "phaser": "^3.90.0"
+  },
+  "devDependencies": {
+    "vite": "^5.4.10"
+  }
+}

--- a/src/main.js
+++ b/src/main.js
@@ -1,0 +1,40 @@
+import Phaser from 'phaser';
+import PreloadScene from './scenes/PreloadScene';
+import HomeScene from './scenes/HomeScene';
+import GameSelectScene from './scenes/GameSelectScene';
+import FishGameScene from './scenes/FishGameScene';
+import SlotGameScene from './scenes/SlotGameScene';
+import RatGameScene from './scenes/RatGameScene';
+import DressRoomScene from './scenes/DressRoomScene';
+
+const config = {
+  type: Phaser.AUTO,
+  width: 390,
+  height: 844,
+  parent: 'app',
+  backgroundColor: '#111111',
+  physics: {
+    default: 'arcade',
+    arcade: {
+      debug: false,
+      gravity: { y: 0 },
+    },
+  },
+  scale: {
+    mode: Phaser.Scale.FIT,
+    autoCenter: Phaser.Scale.CENTER_BOTH,
+    width: 390,
+    height: 844,
+  },
+  scene: [
+    PreloadScene,
+    HomeScene,
+    GameSelectScene,
+    FishGameScene,
+    SlotGameScene,
+    RatGameScene,
+    DressRoomScene,
+  ],
+};
+
+new Phaser.Game(config);

--- a/src/scenes/DressRoomScene.js
+++ b/src/scenes/DressRoomScene.js
@@ -1,0 +1,48 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+import { createCatContainer } from '../utils/CatRenderer';
+
+const ITEMS = {
+  모자: [{ name: '기본', key: 'acc_none' }],
+  의상: [{ name: '기본', key: 'clothes_none' }],
+  악세사리: [{ name: '기본', key: 'acc_none' }],
+  배경: [{ name: '사무실', key: 'bg_office' }],
+  표정: [{ name: '무표정', key: 'exp_neutral' }],
+};
+
+export default class DressRoomScene extends Phaser.Scene {
+  constructor() {
+    super('DressRoomScene');
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#f4efff');
+    this.add.text(195, 60, '드레스룸', { fontSize: '34px', color: '#2e2355', fontStyle: 'bold' }).setOrigin(0.5);
+
+    createCatContainer(this, 195, 360, gameState.get(this, 'equipped'), 1.25);
+
+    this.add.rectangle(195, 740, 380, 180, 0xffffff, 0.7).setStrokeStyle(2, 0x2a2450);
+
+    Object.keys(ITEMS).forEach((category, idx) => {
+      const x = 45 + idx * 75;
+      const tab = this.add.rectangle(x, 680, 68, 38, 0xcbbaf8).setStrokeStyle(1, 0x2a2450).setInteractive({ useHandCursor: true });
+      this.add.text(x, 680, category, { fontSize: '14px', color: '#2a2450' }).setOrigin(0.5);
+      tab.on('pointerdown', () => this.showCategory(category));
+    });
+
+    this.itemList = this.add.text(195, 752, '카테고리를 눌러 아이템 리스트를 확인하세요.', {
+      fontSize: '16px', color: '#2a2450', align: 'center', wordWrap: { width: 340 },
+    }).setOrigin(0.5);
+
+    const back = this.add.rectangle(195, 810, 170, 50, 0xaed6ff).setStrokeStyle(2, 0x2a2450).setInteractive({ useHandCursor: true });
+    this.add.text(195, 810, '홈으로', { fontSize: '22px', color: '#1f1f1f' }).setOrigin(0.5);
+    back.on('pointerdown', () => this.scene.start('HomeScene'));
+  }
+
+  showCategory(category) {
+    const list = ITEMS[category].map((item) => `- ${item.name} (${item.key})`).join('\n');
+    this.itemList.setText(`[${category}] 아이템 목록\n${list}`);
+  }
+}
+
+export { ITEMS };

--- a/src/scenes/FishGameScene.js
+++ b/src/scenes/FishGameScene.js
@@ -1,0 +1,135 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+
+export default class FishGameScene extends Phaser.Scene {
+  constructor() {
+    super('FishGameScene');
+    this.score = 0;
+    this.gainedCoins = 0;
+    this.timeLeft = 60;
+    this.items = null;
+    this.ended = false;
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#e6f6ff');
+
+    if (!gameState.consumeStamina(this, 1)) {
+      this.scene.start('HomeScene');
+      return;
+    }
+
+    this.add.text(195, 38, '생선 세금 징수', {
+      fontSize: '30px',
+      fontStyle: 'bold',
+      color: '#14425e',
+    }).setOrigin(0.5);
+
+    this.scoreText = this.add.text(20, 86, '점수: 0', { fontSize: '22px', color: '#143648' });
+    this.coinText = this.add.text(20, 118, '획득 코인: 0', { fontSize: '22px', color: '#143648' });
+    this.timerText = this.add.text(20, 150, '남은 시간: 60', { fontSize: '22px', color: '#143648' });
+
+    this.items = this.physics.add.group();
+
+    this.spawnTimer = this.time.addEvent({
+      delay: 550,
+      callback: this.spawnItem,
+      callbackScope: this,
+      loop: true,
+    });
+
+    this.countdown = this.time.addEvent({
+      delay: 1000,
+      loop: true,
+      callback: () => {
+        this.timeLeft -= 1;
+        this.timerText.setText(`남은 시간: ${this.timeLeft}`);
+        if (this.timeLeft <= 0) {
+          this.endGame();
+        }
+      },
+    });
+  }
+
+  spawnItem() {
+    const isFish = Math.random() > 0.35;
+    const texture = isFish ? 'item_fish' : 'item_rat';
+    const x = Phaser.Math.Between(30, 360);
+
+    const item = this.physics.add.image(x, -20, texture)
+      .setInteractive({ useHandCursor: true })
+      .setData('isFish', isFish);
+
+    item.body.setVelocityY(Phaser.Math.Between(180, 300));
+
+    item.on('pointerdown', () => {
+      if (item.getData('isFish')) {
+        this.score += 1;
+        this.gainedCoins += 2;
+      } else {
+        this.score -= 2;
+      }
+      this.refreshUi();
+      item.destroy();
+    });
+
+    this.items.add(item);
+  }
+
+  refreshUi() {
+    this.scoreText.setText(`점수: ${this.score}`);
+    this.coinText.setText(`획득 코인: ${this.gainedCoins}`);
+  }
+
+  update() {
+    this.items.getChildren().forEach((item) => {
+      if (item.y > 900) {
+        item.destroy();
+      }
+    });
+  }
+
+  endGame() {
+    if (this.ended) return;
+    this.ended = true;
+
+    this.spawnTimer.remove(false);
+    this.countdown.remove(false);
+
+    this.items.getChildren().forEach((item) => item.destroy());
+
+    if (this.gainedCoins > 0) {
+      gameState.addCoins(this, this.gainedCoins);
+    }
+
+    const overlay = this.add.rectangle(195, 422, 330, 260, 0x000000, 0.74)
+      .setStrokeStyle(2, 0xffffff);
+
+    this.add.text(195, 350, '노동 종료!', {
+      fontSize: '30px',
+      color: '#ffffff',
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+
+    this.add.text(195, 410, `최종 점수: ${this.score}\n획득 코인: ${this.gainedCoins}`, {
+      fontSize: '24px',
+      color: '#ffffff',
+      align: 'center',
+    }).setOrigin(0.5);
+
+    const backBtn = this.add.rectangle(195, 500, 180, 50, 0xffd260, 1)
+      .setStrokeStyle(2, 0x222222)
+      .setInteractive({ useHandCursor: true });
+
+    this.add.text(195, 500, '홈으로 복귀', {
+      fontSize: '22px',
+      color: '#222222',
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+
+    backBtn.on('pointerdown', () => {
+      overlay.destroy();
+      this.scene.start('HomeScene');
+    });
+  }
+}

--- a/src/scenes/GameSelectScene.js
+++ b/src/scenes/GameSelectScene.js
@@ -1,0 +1,38 @@
+import Phaser from 'phaser';
+
+const GAMES = [
+  { label: '생선 세금 징수', scene: 'FishGameScene' },
+  { label: '츄르 복권', scene: 'SlotGameScene' },
+  { label: '쥐 단속', scene: 'RatGameScene' },
+  { label: '준비 중', scene: null },
+];
+
+export default class GameSelectScene extends Phaser.Scene {
+  constructor() {
+    super('GameSelectScene');
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#fff7ef');
+    this.add.text(195, 70, '미니게임 선택', { fontSize: '32px', color: '#3d2f2f', fontStyle: 'bold' }).setOrigin(0.5);
+
+    GAMES.forEach((game, idx) => {
+      const col = idx % 2;
+      const row = Math.floor(idx / 2);
+      const x = 105 + col * 180;
+      const y = 250 + row * 160;
+      const card = this.add.rectangle(x, y, 150, 120, 0xffd9a8).setStrokeStyle(2, 0x3a2f2f).setInteractive({ useHandCursor: true });
+      this.add.text(x, y, game.label, { fontSize: '20px', color: '#2d2d2d', align: 'center', wordWrap: { width: 128 } }).setOrigin(0.5);
+
+      card.on('pointerdown', () => {
+        if (game.scene) this.scene.start(game.scene);
+      });
+    });
+
+    const home = this.add.rectangle(195, 780, 170, 50, 0xa2c7ff).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(195, 780, '홈', { fontSize: '24px', color: '#1f1f1f' }).setOrigin(0.5);
+    home.on('pointerdown', () => this.scene.start('HomeScene'));
+  }
+}
+
+export { GAMES };

--- a/src/scenes/HomeScene.js
+++ b/src/scenes/HomeScene.js
@@ -1,0 +1,71 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+import { createCatContainer } from '../utils/CatRenderer';
+
+export default class HomeScene extends Phaser.Scene {
+  constructor() {
+    super('HomeScene');
+    this.uiTexts = {};
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#f9f7ff');
+    gameState.startGlobalTimers(this);
+
+    this.add.text(195, 48, '츄르앤더시티', {
+      fontSize: '28px',
+      color: '#2c2c2c',
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+
+    this.uiTexts.coins = this.add.text(20, 90, '', { fontSize: '20px', color: '#46342f' });
+    this.uiTexts.stamina = this.add.text(20, 120, '', { fontSize: '20px', color: '#46342f' });
+    this.uiTexts.mood = this.add.text(20, 150, '', { fontSize: '20px', color: '#46342f' });
+
+    createCatContainer(this, 195, 360, gameState.get(this, 'equipped'), 1.1);
+
+    this.add.text(195, 530, 'Zero 😼  |  Suga 😺', { fontSize: '20px', color: '#5a5a5a' }).setOrigin(0.5);
+
+    this.createButton(195, 650, '게임 시작', () => this.scene.start('GameSelectScene'));
+    this.createButton(195, 730, '드레스룸', () => this.scene.start('DressRoomScene'));
+    this.createButton(195, 800, '간식 주기 (-30 코인 / +20 기분)', () => {
+      if (!gameState.feedSnack(this)) this.showToast('코인이 부족합니다 😿');
+    }, 300, 44, '#f3c15f');
+
+    this.updateHud();
+    this.game.events.on('state:changed', this.updateHud, this);
+    this.game.events.on('game:alert', this.showToast, this);
+    this.events.once('shutdown', this.shutdown, this);
+  }
+
+  updateHud() {
+    this.uiTexts.coins.setText(`츄르값: ${gameState.get(this, 'coins')}`);
+    this.uiTexts.stamina.setText(`집사 체력: ${gameState.get(this, 'stamina')} / 10`);
+    this.uiTexts.mood.setText(`고양이 기분: ${gameState.get(this, 'catMood')} / 100`);
+  }
+
+  showToast(message) {
+    const toast = this.add.text(195, 588, message, {
+      fontSize: '16px',
+      color: '#fff',
+      backgroundColor: '#333',
+      padding: { x: 10, y: 6 },
+    }).setOrigin(0.5);
+
+    this.tweens.add({ targets: toast, alpha: 0, y: 560, delay: 1200, duration: 500, onComplete: () => toast.destroy() });
+  }
+
+  createButton(x, y, label, callback, w = 220, h = 54, color = '#87b6ff') {
+    const rect = this.add.rectangle(x, y, w, h, Phaser.Display.Color.HexStringToColor(color).color)
+      .setStrokeStyle(2, 0x2a2a2a)
+      .setInteractive({ useHandCursor: true });
+
+    this.add.text(x, y, label, { fontSize: '20px', color: '#1b1b1b', fontStyle: 'bold' }).setOrigin(0.5);
+    rect.on('pointerdown', callback);
+  }
+
+  shutdown() {
+    this.game.events.off('state:changed', this.updateHud, this);
+    this.game.events.off('game:alert', this.showToast, this);
+  }
+}

--- a/src/scenes/PreloadScene.js
+++ b/src/scenes/PreloadScene.js
@@ -1,0 +1,23 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+import { createPlaceholderTextures } from '../utils/CatRenderer';
+
+export default class PreloadScene extends Phaser.Scene {
+  constructor() {
+    super('PreloadScene');
+  }
+
+  preload() {
+    // PNG 에셋 추가 예시
+    // this.load.image('body_tuxedo', 'assets/cat/body_tuxedo.png');
+    // this.load.image('coat_black', 'assets/cat/coat_black.png');
+    // this.load.image('hat_crown', 'assets/items/hat_crown.png');
+    // this.load.image('bg_office', 'assets/backgrounds/bg_office.png');
+  }
+
+  create() {
+    gameState.initRegistry(this);
+    createPlaceholderTextures(this);
+    this.scene.start('HomeScene');
+  }
+}

--- a/src/scenes/RatGameScene.js
+++ b/src/scenes/RatGameScene.js
@@ -1,0 +1,47 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+
+export default class RatGameScene extends Phaser.Scene {
+  constructor() {
+    super('RatGameScene');
+    this.kills = 0;
+    this.timeLeft = 20;
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#fff3f3');
+
+    if (!gameState.consumeStamina(this, 1)) {
+      this.scene.start('HomeScene');
+      return;
+    }
+
+    this.add.text(195, 70, '쥐 단속 🐀', { fontSize: '34px', color: '#7a2f2f', fontStyle: 'bold' }).setOrigin(0.5);
+    this.hud = this.add.text(195, 120, '처치: 0 | 남은시간: 20', { fontSize: '22px', color: '#333' }).setOrigin(0.5);
+
+    this.rat = this.add.image(195, 420, 'item_rat').setScale(2).setInteractive({ useHandCursor: true });
+    this.rat.on('pointerdown', () => {
+      this.kills += 1;
+      this.rat.setPosition(Phaser.Math.Between(40, 350), Phaser.Math.Between(190, 720));
+      this.refresh();
+    });
+
+    this.timer = this.time.addEvent({
+      delay: 1000,
+      loop: true,
+      callback: () => {
+        this.timeLeft -= 1;
+        this.refresh();
+        if (this.timeLeft <= 0) {
+          const reward = this.kills * 3;
+          gameState.addCoins(this, reward);
+          this.scene.start('GameSelectScene');
+        }
+      },
+    });
+  }
+
+  refresh() {
+    this.hud.setText(`처치: ${this.kills} | 남은시간: ${this.timeLeft}`);
+  }
+}

--- a/src/scenes/SlotGameScene.js
+++ b/src/scenes/SlotGameScene.js
@@ -1,0 +1,34 @@
+import Phaser from 'phaser';
+import gameState from '../utils/GameState';
+
+export default class SlotGameScene extends Phaser.Scene {
+  constructor() {
+    super('SlotGameScene');
+  }
+
+  create() {
+    this.cameras.main.setBackgroundColor('#f5f1ff');
+    this.add.text(195, 70, '츄르 복권 🎰', { fontSize: '34px', color: '#3d2f7a', fontStyle: 'bold' }).setOrigin(0.5);
+
+    this.result = this.add.text(195, 350, '코인 10을 내고 레버를 당기세요!', { fontSize: '22px', color: '#2d2d2d', align: 'center' }).setOrigin(0.5);
+
+    const spinBtn = this.add.rectangle(195, 430, 220, 60, 0xffdf71).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(195, 430, '복권 돌리기 (-10)', { fontSize: '24px', color: '#2d2d2d' }).setOrigin(0.5);
+
+    spinBtn.on('pointerdown', () => {
+      if (!gameState.spendCoins(this, 10)) {
+        this.result.setText('코인이 부족합니다 😿');
+        return;
+      }
+      const multipliers = [0, 1, 2, 3, 5];
+      const m = Phaser.Utils.Array.GetRandom(multipliers);
+      const reward = 10 * m;
+      gameState.addCoins(this, reward);
+      this.result.setText(`배율 x${m}!\n보상 코인 +${reward}`);
+    });
+
+    const back = this.add.rectangle(195, 800, 170, 50, 0xaed6ff).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(195, 800, '뒤로', { fontSize: '22px', color: '#1f1f1f' }).setOrigin(0.5);
+    back.on('pointerdown', () => this.scene.start('GameSelectScene'));
+  }
+}

--- a/src/utils/CatRenderer.js
+++ b/src/utils/CatRenderer.js
@@ -1,0 +1,79 @@
+import Phaser from 'phaser';
+
+const LAYER_ORDER = ['background', 'tail', 'body', 'coat', 'clothes', 'accessories', 'expression'];
+
+export function createCatContainer(scene, x, y, equipped, scale = 1) {
+  const container = scene.add.container(x, y);
+
+  LAYER_ORDER.forEach((layer) => {
+    const textureKey = equipped[layer];
+    if (!textureKey || !scene.textures.exists(textureKey)) return;
+    container.add(scene.add.image(0, 0, textureKey).setOrigin(0.5).setScale(scale));
+  });
+
+  return container;
+}
+
+export function createPlaceholderTextures(scene) {
+  const has = (key) => scene.textures.exists(key);
+
+  if (!has('bg_office')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0xe8eefc, 1).fillRoundedRect(0, 0, 240, 260, 24);
+    g.fillStyle(0xd5def7, 1).fillRect(0, 195, 240, 65);
+    g.generateTexture('bg_office', 240, 260);
+    g.destroy();
+  }
+
+  if (!has('tail_default')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0x222222, 1).fillEllipse(80, 155, 70, 36);
+    g.generateTexture('tail_default', 240, 260);
+    g.destroy();
+  }
+
+  if (!has('body_tuxedo')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0x1f1f1f, 1).fillRoundedRect(70, 70, 100, 130, 40).fillCircle(120, 70, 45);
+    g.generateTexture('body_tuxedo', 240, 260);
+    g.destroy();
+  }
+
+  if (!has('coat_white_chest')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0xffffff, 1).fillTriangle(120, 108, 95, 185, 145, 185);
+    g.generateTexture('coat_white_chest', 240, 260);
+    g.destroy();
+  }
+
+  ['clothes_none', 'acc_none'].forEach((key) => {
+    if (!has(key)) {
+      const g = scene.add.graphics();
+      g.fillStyle(0x000000, 0.001).fillRect(0, 0, 240, 260);
+      g.generateTexture(key, 240, 260);
+      g.destroy();
+    }
+  });
+
+  if (!has('exp_neutral')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0xffffff, 1).fillCircle(103, 66, 5).fillCircle(137, 66, 5).fillRoundedRect(110, 84, 20, 4, 2);
+    g.generateTexture('exp_neutral', 240, 260);
+    g.destroy();
+  }
+
+  if (!has('item_fish')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0x6cc2ff, 1).fillEllipse(24, 15, 30, 16).fillTriangle(8, 15, 0, 8, 0, 22);
+    g.generateTexture('item_fish', 48, 30);
+    g.destroy();
+  }
+
+  if (!has('item_rat')) {
+    const g = scene.add.graphics();
+    g.fillStyle(0x807b88, 1).fillEllipse(18, 16, 26, 16).fillCircle(30, 12, 5);
+    g.lineStyle(2, 0xc2a2b3, 1).strokeLineShape(new Phaser.Geom.Line(4, 16, 0, 22));
+    g.generateTexture('item_rat', 36, 28);
+    g.destroy();
+  }
+}

--- a/src/utils/GameState.js
+++ b/src/utils/GameState.js
@@ -1,0 +1,136 @@
+const clamp = (value, min, max) => Math.max(min, Math.min(max, value));
+
+const INITIAL_STATE = {
+  coins: 0,
+  stamina: 10,
+  catMood: 80,
+  selectedCat: 'zero',
+  equipped: {
+    background: 'bg_office',
+    tail: 'tail_default',
+    body: 'body_tuxedo',
+    coat: 'coat_white_chest',
+    clothes: 'clothes_none',
+    accessories: 'acc_none',
+    expression: 'exp_neutral',
+  },
+};
+
+const STORAGE_KEY = 'churu-and-the-city-save-v1';
+
+class GameState {
+  constructor() {
+    this.state = this._loadFromStorage();
+    this._timersStarted = false;
+  }
+
+  initRegistry(scene) {
+    Object.entries(this.state).forEach(([key, value]) => {
+      scene.registry.set(key, value);
+    });
+  }
+
+  get(scene, key) {
+    const value = scene.registry.get(key);
+    return value === undefined ? this.state[key] : value;
+  }
+
+  set(scene, key, value) {
+    this.state[key] = value;
+    scene.registry.set(key, value);
+    this._save();
+    scene.game.events.emit('state:changed', { key, value, snapshot: { ...this.state } });
+  }
+
+  addCoins(scene, delta) {
+    const nextCoins = Math.max(0, this.get(scene, 'coins') + delta);
+    this.set(scene, 'coins', nextCoins);
+    return nextCoins;
+  }
+
+  spendCoins(scene, amount) {
+    const current = this.get(scene, 'coins');
+    if (current < amount) return false;
+    this.set(scene, 'coins', current - amount);
+    return true;
+  }
+
+  consumeStamina(scene, amount = 1) {
+    const current = this.get(scene, 'stamina');
+    if (current < amount) return false;
+    this.set(scene, 'stamina', current - amount);
+    return true;
+  }
+
+  recoverStamina(scene, amount = 1) {
+    const next = clamp(this.get(scene, 'stamina') + amount, 0, 10);
+    this.set(scene, 'stamina', next);
+    return next;
+  }
+
+  adjustMood(scene, delta) {
+    const next = clamp(this.get(scene, 'catMood') + delta, 0, 100);
+    this.set(scene, 'catMood', next);
+
+    if (next <= 0) {
+      this.set(scene, 'coins', Math.max(0, this.get(scene, 'coins') - 100));
+      this.set(scene, 'catMood', 30);
+      scene.game.events.emit('game:alert', '⚠️ 스트레스성 병동 입원! 츄르값 100 차감');
+    }
+
+    return this.get(scene, 'catMood');
+  }
+
+  feedSnack(scene, snackCost = 30, moodGain = 20) {
+    if (!this.spendCoins(scene, snackCost)) return false;
+    this.adjustMood(scene, moodGain);
+    return true;
+  }
+
+  startGlobalTimers(scene) {
+    if (this._timersStarted) return;
+    this._timersStarted = true;
+
+    // stamina +1 per 5 minutes
+    scene.time.addEvent({
+      delay: 5 * 60 * 1000,
+      loop: true,
+      callback: () => this.recoverStamina(scene, 1),
+    });
+
+    // mood -1 per 2 minutes
+    scene.time.addEvent({
+      delay: 2 * 60 * 1000,
+      loop: true,
+      callback: () => this.adjustMood(scene, -1),
+    });
+  }
+
+  _save() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(this.state));
+    } catch (_) {
+      // ignore storage failures in restricted environments
+    }
+  }
+
+  _loadFromStorage() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return structuredClone(INITIAL_STATE);
+      const parsed = JSON.parse(raw);
+      return {
+        ...structuredClone(INITIAL_STATE),
+        ...parsed,
+        equipped: {
+          ...INITIAL_STATE.equipped,
+          ...(parsed?.equipped || {}),
+        },
+      };
+    } catch (_) {
+      return structuredClone(INITIAL_STATE);
+    }
+  }
+}
+
+export default new GameState();

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,0 +1,7 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  server: {
+    port: 3000,
+  },
+});


### PR DESCRIPTION
### Motivation
- Provide a complete Vite + Phaser 3 mobile-portrait scaffold (390×844) so the project runs in a standard dev flow and matches the requested app structure.  
- Centralize persistent gameplay systems (coins, stamina, catMood) and background timers so resource changes behave consistently across scenes.  
- Support composable cat rendering using layered parts and placeholder vector textures so the project runs without external PNGs while enabling easy asset replacement.  

### Description
- Added Vite app scaffolding: `index.html`, `package.json`, and `vite.config.js`, and updated `README.md` to the requested Korean format and quick-start instructions.  
- Implemented `src/utils/GameState.js` with `initRegistry`, `get`/`set`, `addCoins`/`spendCoins`, stamina consume/recover, `adjustMood` with mood-zero penalty, `feedSnack`, `startGlobalTimers`, and `localStorage` persistence via `_save()` / `_loadFromStorage()`.  
- Implemented `src/utils/CatRenderer.js` providing `createCatContainer(scene, x, y, equipped, scale)` and `createPlaceholderTextures(scene)` with the layer order `background → tail → body → coat → clothes → accessories → expression`.  
- Added and updated scenes: `PreloadScene`, `HomeScene`, `GameSelectScene`, `FishGameScene` (added end-state guard `ended`), `SlotGameScene`, `RatGameScene`, and `DressRoomScene`, and registered them in `src/main.js`; HUDs and snack action now use `GameState`.  

### Testing
- Ran static checks with `node --check` on `src/main.js`, `src/scenes/*.js`, and `src/utils/*.js`, and they completed successfully.  
- Attempted to install runtime deps with `npm install`, but it failed due to a `403 Forbidden` response from the npm registry, so `vite` dev server and browser runtime validation were not executed.  
- Placeholder textures and scene wiring were validated via code inspection and the `PreloadScene`/placeholder texture generation logic to ensure scenes bootstrap without external PNG assets.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699bf2f4e468832c803d2ad0afb371c5)