### PR TITLE
각 미니게임 씬에 게임 종료 버튼 추가

### DIFF
--- a/src/scenes/ChuruSqueezeGameScene.js
+++ b/src/scenes/ChuruSqueezeGameScene.js
@@ -78,9 +78,9 @@ export default class ChuruSqueezeGameScene extends Phaser.Scene {
       },
     });
 
-    const back = this.add.rectangle(195, 800, 170, 50, 0xaed6ff).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
-    this.add.text(195, 800, '뒤로', { fontSize: '22px', color: '#1f1f1f' }).setOrigin(0.5);
-    back.on('pointerdown', () => this.scene.start('GameSelectScene'));
+    const quit = this.add.rectangle(320, 70, 120, 42, 0xffb3b3).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(320, 70, '게임 종료', { fontSize: '18px', color: '#2d2d2d', fontStyle: 'bold' }).setOrigin(0.5);
+    quit.on('pointerdown', () => this.quitGame());
 
     this.events.once('shutdown', this.cleanup, this);
   }
@@ -94,6 +94,13 @@ export default class ChuruSqueezeGameScene extends Phaser.Scene {
       this.countdown.remove(false);
       this.countdown = null;
     }
+  }
+
+  quitGame() {
+    if (this.isGameOver) return;
+    this.isGameOver = true;
+    this.cleanup();
+    this.scene.start('GameSelectScene');
   }
 
   endGame() {

--- a/src/scenes/FishGameScene.js
+++ b/src/scenes/FishGameScene.js
@@ -26,6 +26,16 @@ export default class FishGameScene extends Phaser.Scene {
       color: '#14425e',
     }).setOrigin(0.5);
 
+    const quitBtn = this.add.rectangle(320, 38, 120, 42, 0xffb3b3, 1)
+      .setStrokeStyle(2, 0x222222)
+      .setInteractive({ useHandCursor: true });
+    this.add.text(320, 38, '게임 종료', {
+      fontSize: '18px',
+      color: '#222222',
+      fontStyle: 'bold',
+    }).setOrigin(0.5);
+    quitBtn.on('pointerdown', () => this.quitGame());
+
     this.scoreText = this.add.text(20, 86, '점수: 0', { fontSize: '22px', color: '#143648' });
     this.coinText = this.add.text(20, 118, '획득 코인: 0', { fontSize: '22px', color: '#143648' });
     this.timerText = this.add.text(20, 150, '남은 시간: 60', { fontSize: '22px', color: '#143648' });
@@ -141,5 +151,13 @@ export default class FishGameScene extends Phaser.Scene {
       overlay.destroy();
       this.scene.start('HomeScene');
     });
+  }
+
+  quitGame() {
+    if (this.ended) return;
+    this.ended = true;
+    this.cleanupTimers();
+    this.items.getChildren().forEach((item) => item.destroy());
+    this.scene.start('GameSelectScene');
   }
 }

--- a/src/scenes/KeyboardGameScene.js
+++ b/src/scenes/KeyboardGameScene.js
@@ -53,9 +53,9 @@ export default class KeyboardGameScene extends Phaser.Scene {
       },
     });
 
-    const back = this.add.rectangle(195, 800, 170, 50, 0xaed6ff).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
-    this.add.text(195, 800, '뒤로', { fontSize: '22px', color: '#1f1f1f' }).setOrigin(0.5);
-    back.on('pointerdown', () => this.scene.start('GameSelectScene'));
+    const quit = this.add.rectangle(320, 72, 120, 42, 0xffb3b3).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(320, 72, '게임 종료', { fontSize: '18px', color: '#2d2d2d', fontStyle: 'bold' }).setOrigin(0.5);
+    quit.on('pointerdown', () => this.quitGame());
 
     this.events.once('shutdown', this.cleanup, this);
   }
@@ -106,6 +106,14 @@ export default class KeyboardGameScene extends Phaser.Scene {
       this.countdown.remove(false);
       this.countdown = null;
     }
+  }
+
+  quitGame() {
+    if (this.isGameOver) return;
+    this.isGameOver = true;
+    this.cleanup();
+    this.items.getChildren().forEach((item) => item.destroy());
+    this.scene.start('GameSelectScene');
   }
 
   endGame() {

--- a/src/scenes/RatGameScene.js
+++ b/src/scenes/RatGameScene.js
@@ -9,6 +9,7 @@ export default class RatGameScene extends Phaser.Scene {
   create() {
     this.kills = 0;
     this.timeLeft = 20;
+    this.ended = false;
 
     this.cameras.main.setBackgroundColor('#fff3f3');
 
@@ -18,6 +19,10 @@ export default class RatGameScene extends Phaser.Scene {
     }
 
     this.add.text(195, 70, '쥐 단속 🐀', { fontSize: '34px', color: '#7a2f2f', fontStyle: 'bold' }).setOrigin(0.5);
+    const quit = this.add.rectangle(320, 70, 120, 42, 0xffb3b3).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(320, 70, '게임 종료', { fontSize: '18px', color: '#2d2d2d', fontStyle: 'bold' }).setOrigin(0.5);
+    quit.on('pointerdown', () => this.quitGame());
+
     this.hud = this.add.text(195, 120, '처치: 0 | 남은시간: 20', { fontSize: '22px', color: '#333' }).setOrigin(0.5);
 
     this.rat = this.add.image(195, 420, 'item_rat').setScale(2).setInteractive({ useHandCursor: true });
@@ -50,6 +55,8 @@ export default class RatGameScene extends Phaser.Scene {
   }
 
   endGame() {
+    if (this.ended) return;
+    this.ended = true;
     this.cleanup();
     const reward = this.kills * 3;
     gameState.addCoins(this, reward);
@@ -58,5 +65,12 @@ export default class RatGameScene extends Phaser.Scene {
 
   refresh() {
     this.hud.setText(`처치: ${this.kills} | 남은시간: ${this.timeLeft}`);
+  }
+
+  quitGame() {
+    if (this.ended) return;
+    this.ended = true;
+    this.cleanup();
+    this.scene.start('GameSelectScene');
   }
 }

--- a/src/scenes/SlotGameScene.js
+++ b/src/scenes/SlotGameScene.js
@@ -32,6 +32,10 @@ export default class SlotGameScene extends Phaser.Scene {
     this.cameras.main.setBackgroundColor('#f5f1ff');
     this.add.text(195, 70, '츄르 복권 🎰', { fontSize: '34px', color: '#3d2f7a', fontStyle: 'bold' }).setOrigin(0.5);
 
+    const quit = this.add.rectangle(320, 70, 120, 42, 0xffb3b3).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });
+    this.add.text(320, 70, '게임 종료', { fontSize: '18px', color: '#2d2d2d', fontStyle: 'bold' }).setOrigin(0.5);
+    quit.on('pointerdown', () => this.scene.start('GameSelectScene'));
+
     this.result = this.add.text(195, 350, '코인 10을 내고 레버를 당기세요!', { fontSize: '22px', color: '#2d2d2d', align: 'center' }).setOrigin(0.5);
 
     const spinBtn = this.add.rectangle(195, 430, 220, 60, 0xffdf71).setStrokeStyle(2, 0x2d2d2d).setInteractive({ useHandCursor: true });


### PR DESCRIPTION
### Motivation
- 플레이 중 언제든 게임을 즉시 종료하고 미니게임 목록으로 돌아갈 수 있도록 각 미니게임에 종료 UX를 추가하기 위해 변경했습니다.

### Description
- 모든 미니게임 씬(`FishGameScene`, `SlotGameScene`, `RatGameScene`, `KeyboardGameScene`, `ChuruSqueezeGameScene`)의 상단에 `게임 종료` 버튼을 추가했습니다.
- 각 씬에 `quitGame()`를 추가하거나 기존 종료 로직에 `ended` 플래그/정리 호출을 적용해 타이머와 스폰 오브젝트를 정리한 뒤 `GameSelectScene`으로 이동하도록 했습니다.
- 일부 씬에서는 기존 하단 `뒤로` 버튼을 상단 `게임 종료` 버튼으로 대체해 UX를 일관화했습니다.
- 주요 변경 파일: `src/scenes/FishGameScene.js`, `src/scenes/SlotGameScene.js`, `src/scenes/RatGameScene.js`, `src/scenes/KeyboardGameScene.js`, `src/scenes/ChuruSqueezeGameScene.js`.

### Testing
- `npm run build`를 실행해 번들링이 성공함을 확인했습니다 (성공).
- 개발 서버를 기동한 후 `npm run dev`로 접근해 Playwright 스크립트로 Title→Setup→Home→GameSelect→FishGame 씬으로 진입해 스크린샷을 캡처해 버튼 노출을 확인했습니다 (성공, 스크린샷 생성됨).
- 변경 사항은 로컬에서 빌드/실행 및 간단한 UI 탐색으로 검증되었으며 자동화 스크립트 실행은 모두 성공했습니다.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69afe6f090e0832cbc75b14be4dc5031)